### PR TITLE
add disable loss scaling for Adam/AdamW

### DIFF
--- a/train.py
+++ b/train.py
@@ -275,8 +275,7 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
     scheduler.last_epoch = start_epoch - 1  # do not move
     scaler = amp.GradScaler(enabled=cuda)
     stopper = EarlyStopping(patience=opt.patience)
-    adapt_to_batch_size = opt.optimizer == 'SGD'
-    compute_loss = ComputeLoss(model, adapt_to_batch_size)  # init loss class
+    compute_loss = ComputeLoss(model, adapt_to_batch_size=not opt.disable_loss_scaling)  # init loss class
     LOGGER.info(f'Image sizes {imgsz} train, {imgsz} val\n'
                 f'Using {train_loader.num_workers * WORLD_SIZE} dataloader workers\n'
                 f"Logging results to {colorstr('bold', save_dir)}\n"
@@ -483,6 +482,7 @@ def parse_opt(known=False):
     parser.add_argument('--freeze', nargs='+', type=int, default=[0], help='Freeze layers: backbone=10, first3=0 1 2')
     parser.add_argument('--save-period', type=int, default=-1, help='Save checkpoint every x epochs (disabled if < 1)')
     parser.add_argument('--local_rank', type=int, default=-1, help='DDP parameter, do not modify')
+    parser.add_argument('--disable-loss-scaling', action='store_true', help='disable scaling loss along with batch size')
 
     # Weights & Biases arguments
     parser.add_argument('--entity', default=None, help='W&B: Entity')

--- a/train.py
+++ b/train.py
@@ -275,7 +275,8 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
     scheduler.last_epoch = start_epoch - 1  # do not move
     scaler = amp.GradScaler(enabled=cuda)
     stopper = EarlyStopping(patience=opt.patience)
-    compute_loss = ComputeLoss(model)  # init loss class
+    adapt_to_batch_size = opt.optimizer == 'SGD'
+    compute_loss = ComputeLoss(model, adapt_to_batch_size)  # init loss class
     LOGGER.info(f'Image sizes {imgsz} train, {imgsz} val\n'
                 f'Using {train_loader.num_workers * WORLD_SIZE} dataloader workers\n'
                 f"Logging results to {colorstr('bold', save_dir)}\n"

--- a/utils/loss.py
+++ b/utils/loss.py
@@ -90,7 +90,8 @@ class QFocalLoss(nn.Module):
 
 class ComputeLoss:
     # Compute losses
-    def __init__(self, model, autobalance=False):
+    def __init__(self, model, autobalance=False, adapt_to_batch_size=True):
+        self.adapt_to_batch_size = adapt_to_batch_size
         self.sort_obj_iou = False
         device = next(model.parameters()).device  # get model device
         h = model.hyp  # hyperparameters
@@ -163,8 +164,9 @@ class ComputeLoss:
         lobj *= self.hyp['obj']
         lcls *= self.hyp['cls']
         bs = tobj.shape[0]  # batch size
+        scale = bs if self.adapt_to_batch_size else 1
 
-        return (lbox + lobj + lcls) * bs, torch.cat((lbox, lobj, lcls)).detach()
+        return (lbox + lobj + lcls) * scale, torch.cat((lbox, lobj, lcls)).detach()
 
     def build_targets(self, p, targets):
         # Build targets for compute_loss(), input targets(image,class,x,y,w,h)


### PR DESCRIPTION
# Background

The default behavior scales the learning rate (actually loss) proportionally to batch size, and for SGD we have already verified that the mAP after convergence is universal for variable batch sizes from 16-128 with this setting (https://github.com/ultralytics/yolov5/discussions/2452). It is also supported by the paper [1].

However, for Adam/AdamW, there is no theoretical basis or validation results that it is better to vary the learning rate with such a simple rule.

Therefore, it is reasonable to turn off this behavior by default for Adam/AdamW.

## Changes

* ~~Disable loss scaling along with batch size for Adam/AdamW~~
* Add option `--disable-loss-scaling` to disable loss scaling along with batch size

[1] https://arxiv.org/abs/1706.02677

Translated with www.DeepL.com/Translator (free version)